### PR TITLE
Add translations

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -5,7 +5,8 @@ run_config <- function(
     admin_page,
     skip_if,
     show_if,
-    rate_survey
+    rate_survey,
+    language
 ) {
     # Check for sd_close() in survey.qmd if rate_survey used
     if (rate_survey) { check_sd_close() }
@@ -18,6 +19,9 @@ run_config <- function(
 
     if (files_need_updating) {
         message("Output files not up-to-date - rendering qmd file and extracting content.")
+
+        # Prepare translations (check for inputs)
+        get_translations(paths, language)
 
         # Render the qmd file into the "_survey" folder
         render_qmd(paths)
@@ -117,16 +121,19 @@ check_sd_close <- function() {
 
 get_paths <- function() {
     target_folder <- "_survey"
+
     if (!fs::dir_exists(target_folder)) { fs::dir_create(target_folder)}
+
     paths <- list(
-        qmd           = "survey.qmd",
-        app           = "app.R",
-        target_folder = target_folder,
-        root_html     = "survey.html",
-        target_html   = file.path(target_folder, "survey.html"),
-        target_pages  = file.path(target_folder, "pages.rds"),
-        target_head   = file.path(target_folder, "head.rds"),
-        target_questions  = file.path(target_folder, "questions.yml")
+        qmd              = "survey.qmd",
+        app              = "app.R",
+        root_html        = "survey.html",
+        transl           = "translations.yml",
+        target_transl    = file.path(target_folder, "translations.yml"),
+        target_html      = file.path(target_folder, "survey.html"),
+        target_pages     = file.path(target_folder, "pages.rds"),
+        target_head      = file.path(target_folder, "head.rds"),
+        target_questions = file.path(target_folder, "questions.yml")
     )
     return(paths)
 }
@@ -139,11 +146,93 @@ check_files_need_updating <- function(paths) {
     )
     if (any(!fs::file_exists(targets))) { return(TRUE) }
 
-    # Re-render if the target pages file is out of date with 'survey.qmd' or 'app.R'
+    # Re-render if the target pages file is out of date with 'survey.qmd', 'app.R'
     time_qmd <- file.info(paths$qmd)$mtime
     time_app <- file.info(paths$app)$mtime
     time_pages <- file.info(paths$target_pages)$mtime
-    return((time_qmd > time_pages) || (time_app > time_pages))
+
+    if ((time_qmd > time_pages) || (time_app > time_pages)) { return(TRUE) }
+
+    # Re-render if the user provided a 'translations.yml' file which is out of date
+    if (fs::file_exists(paths$transl)) {
+        
+        time_transl <- file.info(paths$transl)$mtime
+
+        if (time_transl > time_pages) { return(TRUE) }
+    }
+
+    return(FALSE)
+}
+
+get_translations <- function(paths, language) {
+
+    # Check for valid language input (see https://shiny.posit.co/r/reference/shiny/1.7.0/dateinput)
+    valid_languages <- c(
+        "ar", "az", "bg", "bs", "ca", "cs", "cy", "da", "de", "el", "en", 
+        "en-AU", "en-GB", "eo", "es", "et", "eu", "fa", "fi", "fo", "fr-CH", 
+        "fr", "gl", "he", "hr", "hu", "hy", "id", "is", "it-CH", "it", "ja",
+        "ka", "kh", "kk", "ko", "kr", "lt", "lv", "me", "mk", "mn", "ms", "nb",
+        "nl-BE", "nl", "no", "pl", "pt-BR", "pt", "ro", "rs-latin", "rs", "ru",
+        "sk", "sl", "sq", "sr-latin", "sr", "sv", "sw", "th", "tr", "uk", "vi",
+        "zh-CN", "zh-TW"
+    )
+    
+    # Fallback to English if not set or not supported (from shiny::dateInput())
+    if (is.null(language) || !(language %in% valid_languages)) {
+        message("Invalid or unsupported language selected. Falling back to predefined English.")
+        message("Check https://shiny.posit.co/r/reference/shiny/1.7.0/dateinput for supported languages.")
+        language <- "en"  
+    }
+
+    # Include user provided translations (if translations.yml file is in root folder)
+    if (fs::file_exists(paths$transl)) {
+        # Read translations file and select translations for selected language
+        tryCatch({
+            user_transl <- yaml::read_yaml(paths$transl)
+            user_transl <- user_transl[unique(names(user_transl))]
+            user_transl <- user_transl[names(user_transl) == language]
+
+            # Check if there is one valid set of translations for selected language
+            if (length(user_transl) == 1) {
+                message("User provided translations for language '", language, "' from '", paths$transl, "' file loaded.")
+
+                # Add possible missing text elements from predefined translations (if not available, use English)
+                if (language %in% names(translations)) {
+                    predef_transl <- translations[[language]]
+                } else {
+                    predef_transl <- translations[["en"]]
+                }
+                user_transl[[1]] <- c(
+                    user_transl[[1]],
+                    predef_transl[!(names(predef_transl) %in% names(user_transl[[1]]))]
+                )
+
+            } else {
+                user_transl <- NULL
+            }
+        }, error = function(e) {
+            message("Error reading '", paths$transl, "' file. Please review and revise the file. Error details: ", e$message)
+            user_transl <- NULL
+        })
+
+        # Combine user provided translations with predefined translations
+        translations <- c(user_transl, translations) # user provided take precedence
+    }
+
+    # Choose translations by choosen language
+    translations <- translations[names(translations) == language]
+    translations <- translations[1]
+
+    # Fallback to English if no translations found for selected language
+    if (length(translations[[1]]) == 0) {
+        message("No translations found for language '", language, "'. Fall back to predefined English.")
+        message("Surveydown currently provides translations for the following languages: 'en', 'de', 'fr', 'it', and 'es'.")
+        message("Add a translation file to the root folder to provide translations for other supported languages.")
+        translations <- translations[names(translations) == "en"]
+    }
+
+    # write translations file
+    yaml::write_yaml(translations, paths$target_transl)
 }
 
 render_qmd <- function(paths) {

--- a/R/server.R
+++ b/R/server.R
@@ -114,13 +114,8 @@ sd_server <- function(
     auto_scroll = FALSE,
     rate_survey = FALSE,
     language = "en"
-    # TODO check if choosen language is available. 
-    # TODO Check for additional language yaml file
-        # TODO -> if some are missing -> fall back to english language
 ) {
-    # Store the selected language in a global option
-    options(surveydown.language = language)
-
+    
     # Get input, output, and session from the parent environment
     parent_env <- parent.frame()
     input <- get("input", envir = parent_env)
@@ -146,7 +141,8 @@ sd_server <- function(
         admin_page,
         skip_if,
         show_if,
-        rate_survey
+        rate_survey,
+        language
     )
 
     # Initialize local variables ----
@@ -164,7 +160,6 @@ sd_server <- function(
     admin_page         <- config$admin_page
     question_required  <- config$question_required
     page_id_to_index   <- stats::setNames(seq_along(page_ids), page_ids)
-    languages          <- config$languages
 
     # Pre-compute timestamp IDs
     page_ts_ids      <- paste0("time_p_", page_ids)
@@ -416,8 +411,8 @@ sd_server <- function(
             } else if (!is.null(next_page_id)) {
               shinyWidgets::sendSweetAlert(
                 session = session,
-                title = translations[[language]]$warning,
-                text = translations[[language]]$required,
+                title = translations[[language]][["warning"]],
+                text = translations[[language]][["required"]],
                 type = "warning"
               )
             }
@@ -439,11 +434,11 @@ sd_server <- function(
     shiny::observeEvent(input$show_exit_modal, {
       if (rate_survey) {
         shiny::showModal(shiny::modalDialog(
-          title = translations[[language]]$rating_title,
+          title = translations[[language]][["rating_title"]],
           sd_question(
             type   = 'mc_buttons',
             id     = 'survey_rating',
-            label  = glue:glue("{translations[[language]]$rating_text}:<br><small>({translations[[language]]$rating_scale})</small>"),
+            label  = glue::glue("{translations[[language]][['rating_text']]}:<br><small>({translations[[language]][['rating_scale']]})</small>"),
             option = c(
               "1" = "1",
               "2" = "2",
@@ -453,17 +448,17 @@ sd_server <- function(
             )
           ),
           footer = shiny::tagList(
-            shiny::modalButton(translations[[language]]$cancel),
-            shiny::actionButton("submit_rating", translations[[language]]$submit_exit)
+            shiny::modalButton(translations[[language]][["cancel"]]),
+            shiny::actionButton("submit_rating", translations[[language]][["submit_exit"]])
           )
         ))
       } else {
         shiny::showModal(shiny::modalDialog(
-          title = translations[[language]]$confirm_exit,
-          translations[[language]]$sure_exit,
+          title = translations[[language]][["confirm_exit"]],
+          translations[[language]][["sure_exit"]],
           footer = shiny::tagList(
-            shiny::modalButton(translations[[language]]$cancel),
-            shiny::actionButton("confirm_exit", translations[[language]]$exit)
+            shiny::modalButton(translations[[language]][["cancel"]]),
+            shiny::actionButton("confirm_exit", translations[[language]][["exit"]])
           )
         ))
       }

--- a/R/server.R
+++ b/R/server.R
@@ -89,7 +89,8 @@
 #'       start_page = NULL,
 #'       admin_page = FALSE,
 #'       auto_scroll = FALSE,
-#'       rate_survey = FALSE
+#'       rate_survey = FALSE,
+#'       language = "en"
 #'     )
 #'   }
 #'
@@ -111,8 +112,14 @@ sd_server <- function(
     start_page = NULL,
     admin_page = FALSE,
     auto_scroll = FALSE,
-    rate_survey = FALSE
+    rate_survey = FALSE,
+    language = "en"
+    # TODO check if choosen language is available. 
+    # TODO Check for additional language yaml file
+        # TODO -> if some are missing -> fall back to english language
 ) {
+    # Store the selected language in a global option
+    options(surveydown.language = language)
 
     # Get input, output, and session from the parent environment
     parent_env <- parent.frame()
@@ -157,6 +164,7 @@ sd_server <- function(
     admin_page         <- config$admin_page
     question_required  <- config$question_required
     page_id_to_index   <- stats::setNames(seq_along(page_ids), page_ids)
+    languages          <- config$languages
 
     # Pre-compute timestamp IDs
     page_ts_ids      <- paste0("time_p_", page_ids)
@@ -408,8 +416,8 @@ sd_server <- function(
             } else if (!is.null(next_page_id)) {
               shinyWidgets::sendSweetAlert(
                 session = session,
-                title = "Warning",
-                text = "Please answer all required questions before proceeding.",
+                title = translations[[language]]$warning,
+                text = translations[[language]]$required,
                 type = "warning"
               )
             }
@@ -431,11 +439,11 @@ sd_server <- function(
     shiny::observeEvent(input$show_exit_modal, {
       if (rate_survey) {
         shiny::showModal(shiny::modalDialog(
-          title = "Before you go...",
+          title = translations[[language]]$rating_title,
           sd_question(
             type   = 'mc_buttons',
             id     = 'survey_rating',
-            label  = "Rate your survey experience:<br><small>(from 1-poor to 5-excellent)</small>",
+            label  = glue:glue("{translations[[language]]$rating_text}:<br><small>({translations[[language]]$rating_scale})</small>"),
             option = c(
               "1" = "1",
               "2" = "2",
@@ -445,17 +453,17 @@ sd_server <- function(
             )
           ),
           footer = shiny::tagList(
-            shiny::modalButton("Cancel"),
-            shiny::actionButton("submit_rating", "Submit and Exit")
+            shiny::modalButton(translations[[language]]$cancel),
+            shiny::actionButton("submit_rating", translations[[language]]$submit_exit)
           )
         ))
       } else {
         shiny::showModal(shiny::modalDialog(
-          title = "Confirm Exit",
-          "Are you sure you want to exit the survey?",
+          title = translations[[language]]$confirm_exit,
+          translations[[language]]$sure_exit,
           footer = shiny::tagList(
-            shiny::modalButton("Cancel"),
-            shiny::actionButton("confirm_exit", "Exit")
+            shiny::modalButton(translations[[language]]$cancel),
+            shiny::actionButton("confirm_exit", translations[[language]]$exit)
           )
         ))
       }

--- a/R/translation.R
+++ b/R/translation.R
@@ -42,5 +42,71 @@ translations <- list(
     "seconds" = 'Sekunden',
     "new_tab" = 'Öffnet sich in einem neuen Tab',
     "redirect_error" = "Fehler: Dieser Text wird keine Weiterleitung auslösen..."
+  ),
+  "es" = list(
+    #server.R
+    "cancel" = 'Cancelar',
+    "confirm_exit" = 'Confirmar Salida',
+    "sure_exit" = '¿Está seguro de que desea salir de la encuesta?',
+    "submit_exit" = 'Enviar y Salir',
+    "warning" = 'Advertencia',
+    "required" = 'Por favor, responda todas las preguntas obligatorias antes de continuar.',
+    "rating_title" = 'Antes de irse...',
+    "rating_text"  = 'Califique su experiencia en la encuesta:',
+    "rating_scale" = 'de 1-malo a 5-excelente',
+    # ui.R
+    "next" = 'Siguiente',
+    "exit" = 'Salir de la Encuesta',
+    "close_tab" = 'Por favor, cierre esta pestaña manualmente para salir de la encuesta.',
+    "choose_option" = "Elija una opción...",
+    "click" = 'Haga clic aquí',
+    "redirect" = 'Redireccionando en',
+    "seconds" = 'segundos',
+    "new_tab" = 'Se abre en una nueva pestaña',
+    "redirect_error" = "Error: Este texto no activará ninguna redirección..."
+  ),
+  "fr" = list(
+    #server.R
+    "cancel" = 'Annuler',
+    "confirm_exit" = 'Confirmer la sortie',
+    "sure_exit" = 'Êtes-vous sûr de vouloir quitter le sondage?',
+    "submit_exit" = 'Soumettre et quitter',
+    "warning" = 'Avertissement',
+    "required" = 'Veuillez répondre à toutes les questions obligatoires avant de continuer.',
+    "rating_title" = 'Avant de partir...',
+    "rating_text"  = 'Évaluez votre expérience du sondage :',
+    "rating_scale" = 'de 1-mauvais à 5-excellent',
+    # ui.R
+    "next" = 'Suivant',
+    "exit" = 'Quitter le sondage',
+    "close_tab" = 'Veuillez fermer cet onglet manuellement pour quitter le sondage.',
+    "choose_option" = "Choisissez une option...",
+    "click" = 'Cliquez ici',
+    "redirect" = 'Redirection dans',
+    "seconds" = 'secondes',
+    "new_tab" = "S'ouvre dans un nouvel onglet",
+    "redirect_error" = "Erreur : Ce texte n'activera aucune redirection..."
+  ),
+  "it" = list(
+    #server.R
+    "cancel" = 'Annulla',
+    "confirm_exit" = 'Conferma Uscita',
+    "sure_exit" = 'Sei sicuro di voler uscire dal sondaggio?',
+    "submit_exit" = 'Invia ed Esci',
+    "warning" = 'Avviso',
+    "required" = 'Per favore, rispondi a tutte le domande obbligatorie prima di procedere.',
+    "rating_title" = 'Prima di andare...',
+    "rating_text"  = 'Valuta la tua esperienza con il sondaggio:',
+    "rating_scale" = 'da 1-scarso a 5-eccellente',
+    # ui.R
+    "next" = 'Avanti',
+    "exit" = 'Esci dal Sondaggio',
+    "close_tab" = 'Per favore, chiudi questa scheda manualmente per uscire dal sondaggio.',
+    "choose_option" = "Scegli un'opzione...",
+    "click" = 'Clicca qui',
+    "redirect" = 'Reindirizzamento in',
+    "seconds" = 'secondi',
+    "new_tab" = 'Si apre in una nuova scheda',
+    "redirect_error" = "Errore: Questo testo non attiverà alcun reindirizzamento..."
   )
 )

--- a/R/translation.R
+++ b/R/translation.R
@@ -1,0 +1,36 @@
+translations <- list(
+  en = list(
+    next = 'Next',
+    exit = 'Exit Survey',
+    cancel = 'Cancel',
+    exit_confirm = 'Confirm Exit',
+    exit_sure = 'Are you sure you want to exit the survey?',
+    exit_submit = 'Submit and Exit',
+    warning = 'Warning',
+    required = 'Please answer all required questions before proceeding.',
+    rating_title = 'Before you go...',
+    rating_text  = 'Rate your survey experience:',
+    rating_scale = 'from 1-poor to 5-excellent',
+    close_tab = 'Please close this tab manually to exit the survey.',
+    redirect = 'Redirecting in',
+    second = 'seconds',
+    new_tab = 'Opens in a new tab'
+  ),
+  de = list(
+    next = 'Weiter',
+    exit = 'Umfrage beenden',
+    cancel = 'Abbrechen',
+    exit_confirm = 'Beenden bestätigen',
+    exit_sure = 'Sind Sie sicher, dass Sie die Umfrage beenden möchten?',
+    exit_submit = 'Absenden und beenden',
+    warning = 'Warnung',
+    required = 'Bitte beantworten Sie alle erforderlichen Fragen, bevor Sie fortfahren.',
+    rating_title = 'Bevor Sie gehen...',
+    rating_text = 'Bewerten Sie Ihre Umfrageerfahrung:',
+    rating_scale = 'von 1-schlecht bis 5-ausgezeichnet',
+    close_tab = 'Bitte schließen Sie diesen Tab manuell, um die Umfrage zu beenden.',
+    redirect = 'Weiterleitung in',
+    second = 'Sekunden',
+    new_tab = 'Öffnet sich in einem neuen Tab'
+  )
+)

--- a/R/translation.R
+++ b/R/translation.R
@@ -1,36 +1,46 @@
 translations <- list(
-  en = list(
-    next = 'Next',
-    exit = 'Exit Survey',
-    cancel = 'Cancel',
-    exit_confirm = 'Confirm Exit',
-    exit_sure = 'Are you sure you want to exit the survey?',
-    exit_submit = 'Submit and Exit',
-    warning = 'Warning',
-    required = 'Please answer all required questions before proceeding.',
-    rating_title = 'Before you go...',
-    rating_text  = 'Rate your survey experience:',
-    rating_scale = 'from 1-poor to 5-excellent',
-    close_tab = 'Please close this tab manually to exit the survey.',
-    redirect = 'Redirecting in',
-    second = 'seconds',
-    new_tab = 'Opens in a new tab'
+  "en" = list(
+    #server.R
+    "cancel" = 'Cancel',
+    "confirm_exit" = 'Confirm Exit',
+    "sure_exit" = 'Are you sure you want to exit the survey?',
+    "submit_exit" = 'Submit and Exit',
+    "warning" = 'Warning',
+    "required" = 'Please answer all required questions before proceeding.',
+    "rating_title" = 'Before you go...',
+    "rating_text"  = 'Rate your survey experience:',
+    "rating_scale" = 'from 1-poor to 5-excellent',
+    # ui.R
+    "next" = 'Next',
+    "exit" = 'Exit Survey',
+    "close_tab" = 'Please close this tab manually to exit the survey.',
+    "choose_option" = "Choose an option...",
+    "click" = 'Click here',
+    "redirect" = 'Redirecting in',
+    "seconds" = 'seconds',
+    "new_tab" = 'Opens in a new tab',
+    "redirect_error" = "Error: This text won't trigger any redirection..."
   ),
-  de = list(
-    next = 'Weiter',
-    exit = 'Umfrage beenden',
-    cancel = 'Abbrechen',
-    exit_confirm = 'Beenden bestätigen',
-    exit_sure = 'Sind Sie sicher, dass Sie die Umfrage beenden möchten?',
-    exit_submit = 'Absenden und beenden',
-    warning = 'Warnung',
-    required = 'Bitte beantworten Sie alle erforderlichen Fragen, bevor Sie fortfahren.',
-    rating_title = 'Bevor Sie gehen...',
-    rating_text = 'Bewerten Sie Ihre Umfrageerfahrung:',
-    rating_scale = 'von 1-schlecht bis 5-ausgezeichnet',
-    close_tab = 'Bitte schließen Sie diesen Tab manuell, um die Umfrage zu beenden.',
-    redirect = 'Weiterleitung in',
-    second = 'Sekunden',
-    new_tab = 'Öffnet sich in einem neuen Tab'
+  "de" = list(
+    #server.R
+    "cancel" = 'Abbrechen',
+    "confirm_exit" = 'Beenden bestätigen',
+    "sure_exit" = 'Sind Sie sicher, dass Sie die Umfrage beenden möchten?',
+    "submit_exit" = 'Absenden und beenden',
+    "warning" = 'Warnung',
+    "required" = 'Bitte beantworten Sie alle erforderlichen Fragen, bevor Sie fortfahren.',
+    "rating_title" = 'Bevor Sie gehen...',
+    "rating_text" = 'Bewerten Sie Ihre Umfrageerfahrung:',
+    "rating_scale" = 'von 1-schlecht bis 5-ausgezeichnet',
+    # ui.R
+    "next" = 'Weiter',
+    "exit" = 'Umfrage beenden',
+    "close_tab" = 'Bitte schließen Sie diesen Tab manuell, um die Umfrage zu beenden.',
+    "choose_option" = "Option auswählen...",
+    "click" = 'Hier klicken',
+    "redirect" = 'Weiterleitung in',
+    "seconds" = 'Sekunden',
+    "new_tab" = 'Öffnet sich in einem neuen Tab',
+    "redirect_error" = "Fehler: Dieser Text wird keine Weiterleitung auslösen..."
   )
 )

--- a/R/ui.R
+++ b/R/ui.R
@@ -518,7 +518,7 @@ make_question_container <- function(id, object, width) {
 #' }
 #'
 #' @export
-sd_next <- function(next_page = NULL, label = "Next") {
+sd_next <- function(next_page = NULL, label = "Next") { # TODO change label if !en and label == "Next"
   button_id <- "page_id_next"  # Placeholder ID
   shiny::tagList(
     shiny::div(
@@ -608,14 +608,14 @@ sd_close <- function(label = "Exit Survey") {
         onclick = "Shiny.setInputValue('show_exit_modal', true, {priority: 'event'});"
       )
     ),
-    shiny::tags$script(htmltools::HTML("
+    shiny::tags$script(htmltools::HTML(glue::glue("
       Shiny.addCustomMessageHandler('closeWindow', function(message) {
         window.close();
         if (!window.closed) {
-          alert('Please close this tab manually to exit the survey.');
-        }
+          alert('{translations[[language]]$close_tab}');
+        } # TODO : how do I get the translations here in this function?
       });
-    "))
+    ")))
   )
 }
 
@@ -749,10 +749,14 @@ create_redirect_element <- function(id, url, button, label, delay, newtab = FALS
                     element,
                     shiny::p(
                         style = "margin: 0.5rem 0 0 0;",
-                        "Redirecting in ",
+                        translations[[language]]$redirect, " ",
                         shiny::tags$strong(id = countdown_id, delay),
-                        " seconds.",
-                        if (newtab) " (Opens in a new tab)" else NULL
+                        " ", translations[[language]]$seconds, ".",
+                        if (newtab) {
+                          glue:glue(" ({translations[[language]]$new_tab})")
+                        } else {
+                          NULL
+                        }
                     )
                 )
             ),


### PR DESCRIPTION
I have finally managed it and am very happy with the implementation!

1. there is a new translations.R file in the package, which contains all text elements and various translations as a list.
2. the sd_server() function now contains an option that allows the selection of the language (pre-predefined: "en", "de", "es", "fr" or "it").
3. a help file is prepared in the config() function, which saves the text elements ultimately used as translations.yml in _survey.
4. all text output that could be visible to the respondents is taken from this file:

4.1 in server.R are: 
   - warning required questions
   - rating of survey
   - cancel, submit, and exit buttons

4.2 in ui.R these are:
   - next, exit, buttons
   - label for select input "choose and option"
   - date input language (months, week days)
   - redirect elements

I have decided to make the translations available in ui.R as well. On the one hand, there are settings that the user cannot access themselves (e.g. date input, redirect elements). On the other hand, it saves effort for the user and is in the same workflow now. I have written the labels for the Next and Exit buttons so that they are only overwritten if it is not in English and the default has not been changed. So if something is entered manually, this always applies.

There is also the option for users to provide a translations.yml file in the root folder and replace all or individual text elements for a specified language with it. This is then also imported and populated in the corresponding language. In the event of problems, it always falls back to English.
This approach allows users to systematically change individual text elements, which would otherwise not be possible or would require significantly more effort. Changing the accessible label in survey.qmd is still possible without any problems.

However, I was wondering whether it's really still about translations or whether we should call it text_elements or something similar. After all, phrases can also be adapted in English in this way.

I think this approach is promising and now gives me a good feeling of how a questions.yml file provided by the user can be implemented.