### PR TITLE
Drag drop question added from sortable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,6 +53,6 @@ Imports:
     utils,
     xml2,
     yaml,
-    sortsurvey
+    sortable
 URL: https://pkg.surveydown.org
 BugReports: https://github.com/surveydown-dev/surveydown/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,6 +52,7 @@ Imports:
     usethis,
     utils,
     xml2,
-    yaml
+    yaml,
+    sortsurvey
 URL: https://pkg.surveydown.org
 BugReports: https://github.com/surveydown-dev/surveydown/issues

--- a/R/ui.R
+++ b/R/ui.R
@@ -229,7 +229,7 @@ extract_head_content <- function(html_content) {
 #' - "mc_buttons": Multiple choice with button-style options (single selection)
 #' - "mc_multiple_buttons": Multiple choice with button-style options (multiple selections allowed)
 #' - "mc_drag_drop": Multiple choice in which the respondent can reorder the
-#' choices using drag and drop (based on the [sortsurvey rank_list_survey question](sortable::rank_list_survey))
+#' choices using drag and drop based on the [sortable::rank_list] question.
 #' - "text": Single-line text input
 #' - "textarea": Multi-line text input
 #' - "numeric": Numeric input
@@ -373,11 +373,14 @@ sd_question <- function(
 
   } else if(type == "mc_drag_drop") {
 
-      output <- sortsurvey::rank_list_survey(
+      # uses sortable.js via package sortable to implement drag and drop question
+      # sortable_options has a lot more options that we can expose
+
+      output <- sortable::rank_list(
           input_id    = id,
           text      = label,
           labels    = list_name_md_to_html(option),
-          options= sortsurvey::sortable_options(direction  = direction)
+          options= sortable::sortable_options(direction  = direction)
       )
 
   } else if (type == "text") {

--- a/R/ui.R
+++ b/R/ui.R
@@ -228,6 +228,8 @@ extract_head_content <- function(html_content) {
 #' - "mc_multiple": Multiple choice (multiple selections allowed)
 #' - "mc_buttons": Multiple choice with button-style options (single selection)
 #' - "mc_multiple_buttons": Multiple choice with button-style options (multiple selections allowed)
+#' - "mc_drag_drop": Multiple choice in which the respondent can reorder the
+#' choices using drag and drop (based on the [sortsurvey rank_list_survey question](sortable::rank_list_survey))
 #' - "text": Single-line text input
 #' - "textarea": Multi-line text input
 #' - "numeric": Numeric input
@@ -368,6 +370,15 @@ sd_question <- function(
                 %s
             });
         ", id, js_interaction))))
+
+  } else if(type == "mc_drag_drop") {
+
+      output <- sortsurvey::rank_list_survey(
+          input_id    = id,
+          text      = label,
+          labels    = list_name_md_to_html(option),
+          options= sortsurvey::sortable_options(direction  = direction)
+      )
 
   } else if (type == "text") {
 

--- a/man/sd_question.Rd
+++ b/man/sd_question.Rd
@@ -79,6 +79,8 @@ The function supports various question types:
 \item "mc_multiple": Multiple choice (multiple selections allowed)
 \item "mc_buttons": Multiple choice with button-style options (single selection)
 \item "mc_multiple_buttons": Multiple choice with button-style options (multiple selections allowed)
+\item "mc_drag_drop": Multiple choice in which the respondent can reorder the
+choices using drag and drop (based on the \href{sortable::rank_list_survey}{sortsurvey rank_list_survey question})
 \item "text": Single-line text input
 \item "textarea": Multi-line text input
 \item "numeric": Numeric input

--- a/man/sd_question.Rd
+++ b/man/sd_question.Rd
@@ -80,7 +80,7 @@ The function supports various question types:
 \item "mc_buttons": Multiple choice with button-style options (single selection)
 \item "mc_multiple_buttons": Multiple choice with button-style options (multiple selections allowed)
 \item "mc_drag_drop": Multiple choice in which the respondent can reorder the
-choices using drag and drop (based on the \href{sortable::rank_list_survey}{sortsurvey rank_list_survey question})
+choices using drag and drop based on the \link[sortable:rank_list]{sortable::rank_list} question.
 \item "text": Single-line text input
 \item "textarea": Multi-line text input
 \item "numeric": Numeric input

--- a/surveydown.Rproj
+++ b/surveydown.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 3cd6a428-6761-4ab1-aa17-b65c2b0d5267
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/test_rank_question/app.R
+++ b/test_rank_question/app.R
@@ -1,0 +1,41 @@
+# remotes::install_github("surveydown-dev/surveydown", force = TRUE)
+library(surveydown)
+
+# Database setup
+
+# surveydown stores data on a database that you define at https://supabase.com/
+# To connect to a database, update the sd_database() function with details
+# from your supabase database. For this demo, we set ignore = TRUE, which will
+# ignore the settings and won't attempt to connect to the database. This is
+# helpful for local testing if you don't want to record testing data in the
+# database table. See the documentation for details:
+# https://surveydown.org/store-data
+
+db <- sd_database(
+  host   = "",
+  dbname = "",
+  port   = "",
+  user   = "",
+  table  = "",
+  ignore = TRUE
+)
+
+
+# Server setup
+server <- function(input, output, session) {
+
+  # Define any conditional skip logic here (skip to page if a condition is true)
+  sd_skip_if()
+
+  # Define any conditional display logic here (show a question if a condition is true)
+  sd_show_if()
+
+  # Database designation and other settings
+  sd_server(
+    db = db
+  )
+
+}
+
+# shinyApp() initiates your app - don't change it
+shiny::shinyApp(ui = sd_ui(), server = server)

--- a/test_rank_question/survey.Rproj
+++ b/test_rank_question/survey.Rproj
@@ -1,0 +1,22 @@
+Version: 1.0
+
+RestoreWorkspace: No
+SaveWorkspace: No
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+LineEndingConversion: Posix
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/test_rank_question/survey.qmd
+++ b/test_rank_question/survey.qmd
@@ -1,0 +1,79 @@
+---
+echo: false
+warning: false
+---
+
+```{r}
+library(surveydown)
+```
+
+::: {#welcome .sd-page}
+
+# Welcome to our survey!
+
+This is a simple demonstration of a surveydown survey. It has two pages with one question on each page.
+
+Here is a basic "multiple choice" question, created using `type = 'mc'` inside the `sd_question()` function:
+
+```{r}
+sd_question(
+  type  = 'mc',
+  id    = 'penguins',
+  label = "Which type of penguin do you like the best?",
+  option = c(
+    'Adélie'    = 'adelie',
+    'Chinstrap' = 'chinstrap',
+    'Gentoo'    = 'gentoo'
+  )
+)
+
+sd_question(
+  type  = 'mc_drag_drop',
+  id    = 'penguins_drag',
+  label = "Which type of penguin do you like the best?",
+  option = c(
+    'Adélie'    = 'adelie',
+    'Chinstrap' = 'chinstrap',
+    'Gentoo'    = 'gentoo'
+  )
+)
+
+```
+
+You need to insert next buttons with `sd_next()` and set the `next_page` argument to the name of the page you want to go to next.
+
+```{r}
+sd_next(next_page = 'page2')
+```
+
+:::
+
+::: {#page2 .sd-page}
+
+This is another page in your survey.
+
+{surveydown} supports many types of questions. For example, here is a simple `text` type question:
+
+```{r}
+sd_question(
+  type  = "text",
+  id    = "silly_word",
+  label = "Write a silly word here:"
+)
+
+sd_next(next_page = 'end')
+```
+
+:::
+
+::: {#end .sd-page}
+
+## End
+
+This it the last page in the survey.
+
+```{r}
+sd_close("Exit Survey")
+```
+
+:::


### PR DESCRIPTION
I was able to get the sortable drag/drop question to work pretty easily. The original error I found was only relevant to using the rank_list function in a Quarto document. Embedded in the sd_question function, the width/height of the widget is explicitly set and it seems to work fine. I added it as "mc_drag_drop" option in sd_question. The folder test_rank_question contains an example.

The only thing that would remain is to consider exposing more options--there are a whole bunch. Happy to keep working on this & wow it was simple in the end!
