### PR TITLE
Fix custom system-messages not applied to auto-generated nav buttons

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -352,12 +352,15 @@ survey_files_need_updating <- function(paths) {
     return(TRUE)
   }
 
-  # Re-parse if the target pages file is out of date with 'survey.qmd', 'app.R'
+  # Re-parse if the target pages file is out of date with 'survey.qmd', 'app.R',
+  # or 'settings.yml' (which contains system-messages used for nav button labels)
   time_qmd <- file.info(paths$qmd)$mtime
   time_app <- file.info(paths$app)$mtime
+  time_settings <- file.info(paths$target_settings)$mtime
   time_pages <- file.info(paths$target_pages)$mtime
 
-  if ((time_qmd > time_pages) || (time_app > time_pages)) {
+  if ((time_qmd > time_pages) || (time_app > time_pages) ||
+      (time_settings > time_pages)) {
     return(TRUE)
   }
 
@@ -1409,8 +1412,8 @@ extract_html_pages <- function(
             }
 
             # Get translated messages
-            if (!is.null(settings_yaml$system_messages)) {
-              messages <- settings_yaml$system_messages
+            if (!is.null(settings_yaml$`system-messages`)) {
+              messages <- settings_yaml$`system-messages`
             }
           },
           error = function(e) {


### PR DESCRIPTION
I did not manage to set a custom label for automatically generated next buttons (I wanted to translate these into Finnish). Claude's solution below.

  ## Summary

  - **Bug 1:** `extract_html_pages()` reads `settings_yaml$system_messages` (underscore) but the YAML key is `system-messages`
  (hyphen). This causes custom message overrides (e.g., translating "Next" to another language) to be silently ignored for
  auto-generated navigation buttons. Fixed by using backtick-quoted `` `system-messages` ``.

  - **Bug 2:** `survey_files_need_updating()` does not check whether `_survey/settings.yml` is newer than `pages.rds`. Since
  `create_settings_yaml()` runs in `sd_ui()` and may update `settings.yml` (e.g., when `system-messages` are added to the YAML   header), `pages.rds` must be regenerated to pick up the new button labels. Without this check, users must manually delete   `pages.rds` to see updated nav button text.

  ## Reproduction

  1. Add a `system-messages:` block as a top-level YAML key in `survey.qmd` with e.g. `next: "Seuraava"`
  2. Run `shiny::runApp()`
  3. The console shows "Custom system-messages entries found" but the Next button still shows "Next"

  ## Solution

  Two changes in `R/config.R`:

  1. **Line 1412:** Changed `settings_yaml$system_messages` to `settings_yaml$´system-messages´` so `extract_html_pages()`
  correctly reads the kebab-case YAML key.
  2. **Line 355–362:** Added `settings.yml` timestamp to the staleness check in `survey_files_need_updating()`, so `pages.rds` is
  regenerated when settings change.

  Verified locally: after applying the fix, custom `next` labels appear correctly on auto-generated navigation buttons.