### PR TITLE
Preserve markdown/HTML formatting in shuffled mc/mc_multiple question labels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# surveydown (development version)
+
+- Bug fix: Markdown/HTML formatting in `mc` and `mc_multiple` question labels (e.g. `**bold**`) is now preserved when option shuffling is enabled. Previously, shuffled choice questions were re-rendered on the client from a plain-text copy of the label, which stripped bold, italics, and links from the question text. The parsed question structure now carries the label's inline HTML (`label_html`) alongside the existing plain-text `label`.
+
 # surveydown 1.1.3
 
 - New feature: A new `option_attr` parameter for `sd_question()`, limited to the `mc` and `mc_multiple` types. It can be used to define the extra attributes for the designated options with a question mark icon to the right which can be triggered either with hovering or clicking. For example, an `mc` question might have `option = c("option_1, "option_2", "option_3", "option_4")`. Then we can give `option_attr = c("Attribute 1", NA, "Attribute 3")` to define attributes for the 1st and 3rd options.

--- a/R/config.R
+++ b/R/config.R
@@ -1547,10 +1547,33 @@ extract_question_structure_html <- function(html_content) {
       type <- "matrix"
     }
 
-    # Extract the question text (label)
+    # Extract the question text (label) as plain text. This is what most
+    # consumers display (e.g. the `<id>_label_question` text output).
     label <- question_node |>
       rvest::html_nodes("p") |>
       rvest::html_text(trim = TRUE)
+
+    # Also capture the label paragraph(s) as inner HTML, preserving inline
+    # markdown formatting (e.g. **bold** -> <strong>, italics, links). Option-
+    # shuffled mc/mc_multiple questions are re-rendered from this structure on
+    # the client, so without this their formatting would be lost (only plain
+    # text survives `html_text()` above).
+    label_nodes <- rvest::html_nodes(question_node, "p")
+    label_html <- if (length(label_nodes) == 0) {
+      label
+    } else {
+      inner_html <- vapply(
+        seq_along(label_nodes),
+        function(i) {
+          paste(
+            as.character(xml2::xml_contents(label_nodes[[i]])),
+            collapse = ""
+          )
+        },
+        character(1)
+      )
+      trimws(paste(inner_html, collapse = " "))
+    }
 
     # Detect if this is a button-style question (mc_buttons or mc_multiple_buttons)
     # Button-style questions have .btn-group class in their container
@@ -1562,7 +1585,8 @@ extract_question_structure_html <- function(html_content) {
       type = type,
       is_matrix = is_matrix,
       is_button_style = is_button_style,
-      label = label
+      label = label,
+      label_html = label_html
     )
 
     # Extract rows for matrix questions (sub-questions that will be shuffled)

--- a/R/server.R
+++ b/R/server.R
@@ -941,8 +941,14 @@ sd_server <- function(db = NULL) {
 
         shuffled_options <- original_options[order]
 
-        # Get label (handle list format)
-        q_label <- q_struct$label
+        # Get label (handle list format). Prefer label_html, which preserves
+        # inline markdown formatting (e.g. **bold** -> <strong>); fall back to
+        # the plain-text label for structures written before label_html existed.
+        q_label <- if (!is.null(q_struct$label_html)) {
+            q_struct$label_html
+        } else {
+            q_struct$label
+        }
         if (is.list(q_label)) {
             q_label <- q_label[[1]]
         }

--- a/tests/testthat/test-question-label-formatting.R
+++ b/tests/testthat/test-question-label-formatting.R
@@ -1,0 +1,63 @@
+# Regression tests for preserving inline label formatting (e.g. **bold**) when a
+# question is option-shuffled. Shuffled mc/mc_multiple questions are re-rendered
+# on the client from the parsed question structure, so the structure must carry
+# the label's inline HTML (`label_html`) in addition to the plain-text `label`.
+
+test_that("extract_question_structure_html keeps label plain and label_html formatted", {
+  html <- rvest::read_html(paste0(
+    '<div class="question-container" data-question-id="q_fmt">',
+    '<div id="q_fmt" class="form-group shiny-input-checkboxgroup shiny-input-container">',
+    '<label class="control-label" id="q_fmt-label" for="q_fmt">',
+    '<p>Select <strong>all</strong> that apply:</p>',
+    '</label>',
+    '<div class="shiny-options-group">',
+    '<div class="checkbox"><label>',
+    '<input type="checkbox" name="q_fmt" value="a"/><span>Option A</span>',
+    '</label></div>',
+    '<div class="checkbox"><label>',
+    '<input type="checkbox" name="q_fmt" value="b"/><span>Option B</span>',
+    '</label></div>',
+    '</div>',
+    '</div>',
+    '</div>'
+  ))
+
+  structure <- surveydown:::extract_question_structure_html(html)
+  expect_true("q_fmt" %in% names(structure))
+  q <- structure[["q_fmt"]]
+
+  # Plain-text label drops all markup (it feeds the `<id>_label_question` text
+  # output, which would otherwise show literal <strong> tags).
+  expect_equal(q$label, "Select all that apply:")
+  expect_false(grepl("<strong>", q$label, fixed = TRUE))
+
+  # label_html preserves the inline formatting for the shuffled re-render.
+  expect_match(q$label_html, "Select", fixed = TRUE)
+  expect_match(q$label_html, "<strong>all</strong>", fixed = TRUE)
+  expect_match(q$label_html, "that apply", fixed = TRUE)
+})
+
+test_that("label_html falls back to the plain label when there is no formatting", {
+  html <- rvest::read_html(paste0(
+    '<div class="question-container" data-question-id="q_plain">',
+    '<div id="q_plain" class="form-group shiny-input-radiogroup shiny-input-container">',
+    '<label class="control-label" id="q_plain-label" for="q_plain">',
+    '<p>Plain label</p>',
+    '</label>',
+    '</div>',
+    '</div>'
+  ))
+
+  q <- surveydown:::extract_question_structure_html(html)[["q_plain"]]
+  expect_equal(q$label, "Plain label")
+  expect_equal(q$label_html, "Plain label")
+})
+
+test_that("markdown_to_html passes inline HTML through, so re-rendered labels stay formatted", {
+  # generate_shuffled_mc_html() feeds label_html back through sd_question(),
+  # which runs markdown_to_html(). That must preserve the <strong> tag.
+  out <- as.character(
+    surveydown:::markdown_to_html("Select <strong>all</strong> that apply:")
+  )
+  expect_match(out, "<strong>all</strong>", fixed = TRUE)
+})


### PR DESCRIPTION
PR created by Claude.

## Summary
  Markdown formatting in `mc`/`mc_multiple` question labels (e.g. `**bold**`) is
  silently dropped when the question is option-shuffled. This PR preserves it.

  ## Reproduce
  Shuffle an `mc`/`mc_multiple` question whose label contains markdown:

  ```yaml
  survey-settings:
    shuffled: [q_demo]
  ```
  ```r
  sd_question(
    id = "q_demo", type = "mc_multiple",
    label = "Select **all** that apply:",
    option = c("A" = "a", "B" = "b", "C" = "c")
  )
  ```
  The static render shows **all** bold, but in the running app the word is plain.
  Non-shuffled questions render the bold correctly, and markdown in page prose is
  unaffected — so the regression is specific to the shuffle path.

  ## Root cause
  Option-shuffled mc-type questions are re-rendered on the client:
  `generate_shuffled_mc_html()` rebuilds the question from the parsed
  `question_structure` and swaps it into the DOM via `innerHTML`. But the label in
  that structure is extracted with `rvest::html_text()`
  (`extract_question_structure_html()` in `R/config.R`), which strips all inline
  markup to plain text. The regenerated label therefore has no `<strong>`/`<em>`/
  links and overwrites the correctly-rendered static label.

  `label` can't simply become HTML in place: it's also surfaced as plain text via
  the `<id>_label_question` output in `R/server.R`, which would then show literal
  tags.

  ## Fix
  - `extract_question_structure_html()` additionally stores `label_html`, the
    label paragraph's inner HTML, preserving inline formatting. The plain-text
    `label` is unchanged.
  - `generate_shuffled_mc_html()` uses `label_html` when present (falling back to
    `label` for question structures written before this field existed).
    `sd_question()` → `markdown_to_html()` already passes inline HTML through.

  Backward compatible: cached `questions.yml` files without `label_html` fall back
  to prior behavior, and the new field round-trips through
  `write/load_question_structure_yaml` automatically.

  ## Tests
  Adds `tests/testthat/test-question-label-formatting.R`:
  - `extract_question_structure_html()` keeps `label` plain and exposes
    `label_html` with `<strong>` preserved.
  - `label_html` falls back to the plain label when there's no inline formatting.
  - `markdown_to_html()` passes inline HTML through (guards the re-render path).

  Also verified end to end by running a survey with a shuffled `mc_multiple`
  question whose label contains `**bold**`: the option re-render now keeps the
  bold, while non-shuffled questions and the `_label_question` text output are
  unchanged.

  ## Possible follow-up
  A more structural alternative would be to reorder the existing option DOM nodes
  client-side (as matrix-row shuffling already does) instead of fully replacing
  the question HTML, avoiding the label re-render entirely. This PR takes the
  smaller, targeted route.